### PR TITLE
Python 3 지원

### DIFF
--- a/iamport/client.py
+++ b/iamport/client.py
@@ -26,7 +26,7 @@ class Iamport(object):
         if response.status_code != requests.codes.ok:
             return {}
         result = response.json()
-        if result['code'] is not 0:
+        if result['code'] != 0:
             raise Iamport.ResponseError(result.get('code'), result.get('message'))
         return result.get('response')
 

--- a/iamport/client.py
+++ b/iamport/client.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 import requests
 
-TEST_IMP_KEY = 'imp_apikey'
-TEST_IMP_SECRET = 'ekKoeW8RyKuT0zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA5lamv9OqDMnxyeB9wqOsuO9W3Mx9YSJ4dTqJ3f'
+__all__ = ['IAMPORT_API_URL', 'Iamport']
+
 IAMPORT_API_URL = 'https://api.iamport.kr/'
 
 
 class Iamport(object):
-    def __init__(self,
-                 imp_key=TEST_IMP_KEY,
-                 imp_secret=TEST_IMP_SECRET,
-                 imp_url=IAMPORT_API_URL):
+    def __init__(self, imp_key, imp_secret, imp_url=IAMPORT_API_URL):
         self.imp_key = imp_key
         self.imp_secret = imp_secret
         self.imp_url = imp_url

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 exclude = build,.git
 max-line-length = 119

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from pytest import fixture
+
+from iamport import Iamport
+
+
+DEFAULT_TEST_IMP_KEY = 'imp_apikey'
+DEFAULT_TEST_IMP_SECRET = ('ekKoeW8RyKuT0zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA5lamv9O'
+                           'qDMnxyeB9wqOsuO9W3Mx9YSJ4dTqJ3f')
+
+
+def pytest_addoption(parser):
+    parser.addoption('--imp-key', default=DEFAULT_TEST_IMP_KEY,
+                     help='iamport client key for testing '
+                          '[default: %default]')
+    parser.addoption('--imp-secret', default=DEFAULT_TEST_IMP_SECRET,
+                     help='iamport secret key for testing '
+                          '[default: %default]')
+
+
+@fixture
+def iamport(request):
+    imp_key = request.config.getoption('--imp-key')
+    imp_secret = request.config.getoption('--imp-secret')
+    return Iamport(imp_key=imp_key, imp_secret=imp_secret)

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -3,8 +3,7 @@ from iamport import Iamport
 import pytest
 
 
-def test_cancel():
-    iamport = Iamport()
+def test_cancel(iamport):
     with pytest.raises(TypeError):
         iamport.cancel(imp_uid='nothing')
     with pytest.raises(Iamport.ResponseError):

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-from iamport import Iamport
 
 
-def test_find():
-    iamport = Iamport()
+def test_find(iamport):
     result = iamport.find(imp_uid='test')
     assert dict == type(result)
     result = iamport.find(merchant_uid='test')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27, pypy
+
+[testenv]
+deps =
+    pytest
+    flake8
+commands =
+    py.test
+    flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy
+envlist = py27, py34, py35, pypy, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
딱히 수정할 코드는 별로 없었습니다. 주요 로직이 `requests` 모듈을 써서 HTTP 요청과 응답을 주고 받는 것인데, `requests` 모듈은 오래 전부터 Python 3를 잘 지원하고 있었기 때문입니다.

대신 그냥 테스트할 때 항상 지원하는 여러 Python 버전에서 테스트되도록 [tox][] 설정을 했습니다. 이제 [tox][]를 쓰면 한번에 Python 2.7, Python 3.4, Python 3.5, PyPy에서 테스트를 실행하게 됩니다. 아예 [detox][]를 쓰면 병렬로 더 빠르게 실행됩니다:

[![asciicast](https://asciinema.org/a/7giviqmg12p1pfjol29hbbbz0.png)](https://asciinema.org/a/7giviqmg12p1pfjol29hbbbz0)

또, 하는 김에 테스트를 위해 사용되는 클라이언트 키와 비밀키가 하드코딩되어 있던 것을, `py.test`에서 옵션으로 받을 수 있게 했습니다. 옵션을 안 주면 기존에 하드코딩되어 있던 그 키를 기본값으로 사용합니다. `py.test`의 도움말을 출력하면 다음과 같이 나옵니다.

```
$ py.test --help
usage: py.test [options] [file_or_dir] [file_or_dir] [...]

…

custom options:
  --imp-key=IMP_KEY     iamport client key for testing [default: imp_apikey]
  --imp-secret=IMP_SECRET
                        iamport secret key for testing [default: ekKoeW8RyKuT0
                        zgaZsUtXXTLQ4AhPFW3ZGseDA6bkA5lamv9OqDMnxyeB9wqOsuO9W3
                        Mx9YSJ4dTqJ3f]

…

to see available markers type: py.test --markers
to see available fixtures type: py.test --fixtures
(shown according to specified file_or_dir or current dir if not specified)
```

[tox]: http://tox.testrun.org/
[detox]: https://bitbucket.org/hpk42/detox