### PR TITLE
Fixed, build fail

### DIFF
--- a/tests/test_is_paid.py
+++ b/tests/test_is_paid.py
@@ -6,7 +6,7 @@ def test_is_paid_with_response(iamport):
         'status': 'paid',
         'amount': 1000,
     }
-    assert True is iamport.is_paid(amount=1000, resposne=mocked_response, merchant_uid='test')
+    assert True is iamport.is_paid(amount=1000, response=mocked_response, merchant_uid='test')
 
 
 def test_is_paid_without_response(iamport):

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27, py34, py35, py36, pypy
 [testenv]
 passenv = CI TRAVIS TRAVIS_*
 deps =
+    pytest-runner
     pytest
     flake8
     collective.checkdocs


### PR DESCRIPTION
- test_is_paid 코드에 오타로 인해 깨진 테스크 복구
- pypy 테스트시 pytest-runner 를 찾지 못해 테스트 진행이 안되는 문제 해결