### PR TITLE
test_pay_schedule.py 파일 수정

### DIFF
--- a/tests/test_pay_schedule.py
+++ b/tests/test_pay_schedule.py
@@ -70,4 +70,4 @@ def test_pay_schedule(iamport):
         iamport.pay_schedule(**payload_full)
     except iamport.ResponseError as e:
         assert e.code == 1
-        assert u'등록되지 않은 구매자입니다.' in e.message
+        assert u'등록된 고객정보가 없습니다.' in e.message


### PR DESCRIPTION
등록되지 않은 `customer_uid`를 사용하여 `pay_schedule`을 실행하면, 이전에는 "등록되지 않은 구매자입니다."로 나오던 에러 메시지가 현재는 "등록된 고객정보가 없습니다."로 변경되어 나옵니다. 이에 맞춰, `test_pay_schedule.py` 파일을 수정하였습니다 (수정하지 않으면 테스트 실패로 나옵니다).

다음의 커맨드를 이용해서 테스트를 실행하였습니다.
```
python3 -m pytest tests/
```