### PR TITLE
깃헙 액션 pytest-coverage-commenter 삭제

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,6 @@ jobs:
     - name: Run unit tests
       run: |
         python -m pytest --cov=iamport tests
-    - name: Comment on coverage
-      uses: coroo/pytest-coverage-commentator@v1.0.2
-      with:
-        pytest-coverage: .coverage
     - name: Run convention tests
       run: |
         python -m flake8 iamport tests --ignore E203,W503,W504


### PR DESCRIPTION
### 작업 개요
Resource 핸들링 불가로, `pytest-coverage-commenter` 깃헙 액션 삭제 필요.

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
`pytest-coverage-commenter` 깃헙 액션 삭제.

### 생각해볼 문제
`Github Secret` 등록으로 커버리지를 표시하거나 업로드 할 수 있는 방법을 찾아야 할 것 같습니다.
