### PR TITLE
파이썬 2.7 지원 중단

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ jobs:
   includes:
   - python: pypy
     env: RUN_MYPY=false
-  - python: 2.7
-    env: RUN_MYPY=false
   - python: 3.4
     env: RUN_MYPY=false
   - python: 3.5

--- a/iamport/__init__.py
+++ b/iamport/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .client import Iamport
 
 __all__ = ['Iamport']

--- a/iamport/client.py
+++ b/iamport/client.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 
 import requests

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import io
 import os
 
@@ -33,10 +31,6 @@ setup(
     zip_safe=False,
     data_files=[
         (
-            'shared/typehints/python2.7',
-            ['iamport/client.pyi'],
-        ),
-        (
             'shared/typehints/python3.6',
             ['iamport/client.pyi'],
         ),
@@ -60,7 +54,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 from pytest import fixture
 
 from iamport import Iamport
+
 
 DEFAULT_TEST_IMP_KEY = 'imp_apikey'
 DEFAULT_TEST_IMP_SECRET = (

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/test_customer_create.py
+++ b/tests/test_customer_create.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/test_customer_get.py
+++ b/tests/test_customer_get.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 
 

--- a/tests/test_is_paid.py
+++ b/tests/test_is_paid.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 
 def test_is_paid_with_response(iamport):

--- a/tests/test_pay_again.py
+++ b/tests/test_pay_again.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 
 def test_pay_again(iamport):

--- a/tests/test_pay_foreign.py
+++ b/tests/test_pay_foreign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 
 def test_pay_foreign(iamport):

--- a/tests/test_pay_onetime.py
+++ b/tests/test_pay_onetime.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 import string
 

--- a/tests/test_pay_schedule.py
+++ b/tests/test_pay_schedule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import time
 
 

--- a/tests/test_pay_unschedule.py
+++ b/tests/test_pay_unschedule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import time
 
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import random
 import string
 


### PR DESCRIPTION
### 작업 개요
파이썬 공식 커뮤니티에서 해당 버전에 대한 지원이 [중단](https://www.python.org/doc/sunset-python-2/#:~:text=The%20sunset%20date%20has%20now,when%20we%20released%20Python%202.7.)됨에 따라, 아임포트 프로젝트에서도 파이썬 2.7 지원 중단.

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
파이썬 2.7 버전 관련 코드 및 설정 삭제

### 생각해볼 문제
아직 파이썬 2.7 버전을 쓰시는 분들은 아임포트 파이썬 패키지를 0.8.2 버전으로 고정시키고 사용하셔야 할 것 같습니다.
