### PR TITLE
feat: status 값까지 비교하여 find 할 수 있도록 수정

### DIFF
--- a/iamport/client.py
+++ b/iamport/client.py
@@ -77,8 +77,11 @@ class Iamport(object):
         url = '{}payments/status/{}'.format(self.imp_url, status)
         return self._get(url, params=params)
 
-    def find_by_merchant_uid(self, merchant_uid):
-        url = '{}payments/find/{}'.format(self.imp_url, merchant_uid)
+    def find_by_merchant_uid(self, merchant_uid, status=None):
+        url = '{}payments/find/{}'.format(self.imp_url,
+                                          merchant_uid) if status is None else '{}payments/find/{}/{}'.format(
+            self.imp_url, merchant_uid, status)
+        print(url)
         return self._get(url)
 
     def find_by_imp_uid(self, imp_uid):

--- a/iamport/client.py
+++ b/iamport/client.py
@@ -78,10 +78,9 @@ class Iamport(object):
         return self._get(url, params=params)
 
     def find_by_merchant_uid(self, merchant_uid, status=None):
-        url = '{}payments/find/{}'.format(self.imp_url,
-                                          merchant_uid) if status is None else '{}payments/find/{}/{}'.format(
-            self.imp_url, merchant_uid, status)
-        print(url)
+        url = '{}payments/find/{}'.format(self.imp_url, merchant_uid)
+        if status is not None:
+            url = '{}/{}'.format(url, status)
         return self._get(url)
 
     def find_by_imp_uid(self, imp_uid):

--- a/tests/test_find_with_status.py
+++ b/tests/test_find_with_status.py
@@ -1,26 +1,11 @@
 def test_find_with_status(iamport):
-    # Without 'customer_uid'
-    cancelled_payload = {
-        'merchant_uid': '1234qwer',
-        'status': 'cancelled'
-    }
-
-    paid_payload = {
-        'merchant_uid': '1234qwer',
-        'status': 'paid'
-    }
-
-    empty_payload = {
-        'merchant_uid': '1234qwer',
-    }
-
     try:
-        res = iamport.find_by_merchant_uid(**cancelled_payload)
+        iamport.find_by_merchant_uid(merchant_uid='1234qwer', status='cancelled')
     except iamport.HttpError as e:
         assert e.code == 404
 
-    res = iamport.find_by_merchant_uid(**empty_payload)
+    res = iamport.find_by_merchant_uid(merchant_uid='1234qwer')
     assert res['merchant_uid'] == '1234qwer'
 
-    res = iamport.find_by_merchant_uid(**paid_payload)
+    res = iamport.find_by_merchant_uid(merchant_uid='1234qwer', status='paid')
     assert res['merchant_uid'] == '1234qwer'

--- a/tests/test_find_with_status.py
+++ b/tests/test_find_with_status.py
@@ -1,6 +1,7 @@
 def test_find_with_status(iamport):
     try:
-        iamport.find_by_merchant_uid(merchant_uid='1234qwer', status='cancelled')
+        iamport.find_by_merchant_uid(merchant_uid='1234qwer',
+                                     status='cancelled')
     except iamport.HttpError as e:
         assert e.code == 404
 

--- a/tests/test_find_with_status.py
+++ b/tests/test_find_with_status.py
@@ -1,0 +1,26 @@
+def test_find_with_status(iamport):
+    # Without 'customer_uid'
+    cancelled_payload = {
+        'merchant_uid': '1234qwer',
+        'status': 'cancelled'
+    }
+
+    paid_payload = {
+        'merchant_uid': '1234qwer',
+        'status': 'paid'
+    }
+
+    empty_payload = {
+        'merchant_uid': '1234qwer',
+    }
+
+    try:
+        res = iamport.find_by_merchant_uid(**cancelled_payload)
+    except iamport.HttpError as e:
+        assert e.code == 404
+
+    res = iamport.find_by_merchant_uid(**empty_payload)
+    assert res['merchant_uid'] == '1234qwer'
+
+    res = iamport.find_by_merchant_uid(**paid_payload)
+    assert res['merchant_uid'] == '1234qwer'


### PR DESCRIPTION
- https://api.iamport.kr/#!/payments/getPaymentByMerchantUid 의 status parameter 대응

### 작업 개요
iamport rest api 문서에서는 'find' API 에서 status query parameter 까지 지원함
find method 에서 status 값까지 같이 비교하도록 수정하였습니다. 

### 작업 분류
  - [ ] 버그 수정
  - [x] 신규 기능
  - [ ] 프로젝트 구조 변경

### 작업 상세 내용
  1. find_by_merchant_uid 메소드에 status 인자 추가
  2. 기존 버전과 호환성을 위해 default: status=None 으로 사이드이펙트 방지